### PR TITLE
Terminate inaccessible compute instances.

### DIFF
--- a/backend/services/Makefile
+++ b/backend/services/Makefile
@@ -162,11 +162,11 @@ run_host_service_dev: build
 
 run_scaling_service: build
 	$(info running $(BUILD_FOLDER)/scaling-service with localdev configuration...)
-	APP_ENV=localdev $(BUILD_FOLDER)/scaling-service
+	APP_ENV=localdev $(BUILD_FOLDER)/scaling-service -nocleanup
 
 run_scaling_service_localdevwithdb: build
 	$(info running $(BUILD_FOLDER)/scaling-service with localdevwithdb configuration...)
-	APP_ENV=localdevwithdb $(BUILD_FOLDER)/scaling-service
+	APP_ENV=localdevwithdb $(BUILD_FOLDER)/scaling-service -nocleanup
 
 run_scaling_service_dev: build
 	$(info running $(BUILD_FOLDER)/scaling-service with dev (deployed) configuration...)

--- a/backend/services/scaling-service/cleanup.go
+++ b/backend/services/scaling-service/cleanup.go
@@ -35,9 +35,9 @@ var db dbclient.DBClient
 //	}()
 //
 //	wg.Wait()
-func CleanRegion(client subscriptions.WhistGraphQLClient, h hosts.HostHandler) func() {
+func CleanRegion(client subscriptions.WhistGraphQLClient, h hosts.HostHandler, d time.Duration) func() {
 	stop := make(chan struct{})
-	ticker := time.NewTicker(time.Minute)
+	ticker := time.NewTicker(d)
 	var wg sync.WaitGroup
 
 	// Don't bother adding this goroutine to the cleaner's wait group. It will

--- a/backend/services/scaling-service/cleanup.go
+++ b/backend/services/scaling-service/cleanup.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"reflect"
 	"sync"
 	"time"
 
@@ -106,11 +105,29 @@ func do(ctx context.Context, client subscriptions.WhistGraphQLClient, h hosts.Ho
 		return
 	}
 
-	if !reflect.DeepEqual(deleted, ids) {
+	if !equal(deleted, ids) {
 		logger.Errorf("some %s instance rows were not deleted: requested "+
 			"%v, got %v", region, ids, deleted)
 	} else {
 		logger.Info("Successfully removed the following unresponsive instance "+
 			"rows from the database for %s:", region, deleted)
+	}
+}
+
+func equal(u, v []string) bool {
+	if len(u) != len(v) {
+		return false
+	}
+
+	same := true
+	set := make(map[string]struct{}, len(u))
+
+	for _, s := range u {
+		set[s] = struct{}{}
+	}
+
+	for _, s := range v {
+		_, ok := set[s]
+		same = same && ok
 	}
 }

--- a/backend/services/scaling-service/cleanup.go
+++ b/backend/services/scaling-service/cleanup.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 Whist Technologies, Inc.
+
+package main
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	"github.com/whisthq/whist/backend/services/scaling-service/dbclient"
+	"github.com/whisthq/whist/backend/services/scaling-service/hosts"
+	"github.com/whisthq/whist/backend/services/subscriptions"
+	logger "github.com/whisthq/whist/backend/services/whistlogger"
+)
+
+var db dbclient.DBClient
+
+// do marks all unresponsive instances as TERMINATING in the database before
+// subsequently terminating them and finally removing them from the database
+// altogether.
+func do(ctx context.Context, client subscriptions.WhistGraphQLClient, h hosts.HostHandler) {
+	region := h.GetRegion()
+	maxAge := time.Now().Add(-150 * time.Second)
+	ids, err := db.LockBrokenInstances(ctx, client, region, maxAge)
+
+	if err != nil {
+		logger.Errorf("failed to mark unresponsive instances as TERMINATING in "+
+			"region %s: %s", region, err)
+		return
+	} else if len(ids) < 1 {
+		logger.Debugf("Didn't find any unresponsive instances in region %s",
+			region)
+		return
+	}
+
+	if err := h.SpinDownInstances(ctx, ids); err != nil {
+		logger.Errorf("failed to terminate unresponsive instances in region %s:"+
+			"%s", region, err)
+		logger.Errorf("please verify that the instances in %s with the following "+
+			"instance IDs have been terminated and then remove them from the "+
+			"database: %s", region, ids)
+		return
+	}
+
+	deleted, err := db.TerminateLockedInstances(ctx, client, region, ids)
+
+	if err != nil {
+		logger.Errorf("failed to remove unresponsive instances in %s from the "+
+			"database: %s", region, err)
+		return
+	}
+
+	if !reflect.DeepEqual(deleted, ids) {
+		logger.Errorf("some %s instance rows were not deleted: requested "+
+			"%v, got %v", region, ids, deleted)
+	} else {
+		logger.Info("Successfully removed the following unresponsive instance "+
+			"rows from the database for %s:", region, deleted)
+	}
+}

--- a/backend/services/scaling-service/dbclient/cleanup.go
+++ b/backend/services/scaling-service/dbclient/cleanup.go
@@ -14,7 +14,7 @@ import (
 func (c *DBClient) LockBrokenInstances(ctx context.Context, client subscriptions.WhistGraphQLClient, region string, maxAge time.Time) ([]string, error) {
 	var m subscriptions.LockBrokenInstances
 	vars := map[string]interface{}{
-		"maxAge": timestamptz2(maxAge),
+		"maxAge": timestamptz(maxAge),
 		"region": graphql.String(region),
 	}
 
@@ -39,7 +39,7 @@ func (c *DBClient) LockBrokenInstances(ctx context.Context, client subscriptions
 func (c *DBClient) TerminateLockedInstances(ctx context.Context, client subscriptions.WhistGraphQLClient, region string, ids []string) ([]string, error) {
 	var m subscriptions.TerminateLockedInstances
 
-	// We need to pass the instance IDs as a slice of grpahql String type
+	// We need to pass the instance IDs as a slice of graphql String type
 	//instances, not just a normal string slice.
 	_ids := make([]graphql.String, 0, len(ids))
 

--- a/backend/services/scaling-service/dbclient/cleanup.go
+++ b/backend/services/scaling-service/dbclient/cleanup.go
@@ -1,0 +1,66 @@
+package dbclient
+
+import (
+	"context"
+	"time"
+
+	"github.com/hasura/go-graphql-client"
+	"github.com/whisthq/whist/backend/services/subscriptions"
+)
+
+// LockBrokenInstances sets the column of each row of the database corresponding
+// to an instance that hasn't been updated since maxAge to TERMINATING. It
+// returns the instance ID of every such instance.
+func (c *DBClient) LockBrokenInstances(ctx context.Context, client subscriptions.WhistGraphQLClient, region string, maxAge time.Time) ([]string, error) {
+	var m subscriptions.LockBrokenInstances
+	vars := map[string]interface{}{
+		"maxAge": timestamptz2(maxAge),
+		"region": graphql.String(region),
+	}
+
+	if err := client.Mutate(ctx, &m, vars); err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, m.Response.Count)
+
+	for _, host := range m.Response.Hosts {
+		ids = append(ids, string(host.ID))
+	}
+
+	return ids, nil
+}
+
+// TerminatedLockedInstances removes the requested rows, all of whose status
+// columns should have TERMINATING, corresponding to unresponsive instances from
+// the whist.instances table of the database. It also deletes all rows from the
+// whist.mandelboxes table that are foreign keyed to a whist.instances row whose
+// deletion has been requested.
+func (c *DBClient) TerminateLockedInstances(ctx context.Context, client subscriptions.WhistGraphQLClient, region string, ids []string) ([]string, error) {
+	var m subscriptions.TerminateLockedInstances
+
+	// We need to pass the instance IDs as a slice of grpahql String type
+	//instances, not just a normal string slice.
+	_ids := make([]graphql.String, 0, len(ids))
+
+	for _, id := range ids {
+		_ids = append(_ids, graphql.String(id))
+	}
+
+	vars := map[string]interface{}{
+		"ids":    _ids,
+		"region": graphql.String(region),
+	}
+
+	if err := client.Mutate(ctx, &m, vars); err != nil {
+		return nil, err
+	}
+
+	terminated := make([]string, 0, m.InstancesResponse.Count)
+
+	for _, host := range m.InstancesResponse.Hosts {
+		terminated = append(terminated, string(host.ID))
+	}
+
+	return terminated, nil
+}

--- a/backend/services/scaling-service/dbclient/cleanup_test.go
+++ b/backend/services/scaling-service/dbclient/cleanup_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2022 Whist Technologies, Inc.
+
+package dbclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/hasura/go-graphql-client"
+	"github.com/whisthq/whist/backend/services/subscriptions"
+)
+
+var pkg DBClient
+
+// mockResponse generates a mock GraphQL mutation response.
+func mockResponse(field string, ids []string) ([]byte, error) {
+	// The response contains a list of instance IDs.
+	type host struct {
+		ID string `json:"id"`
+	}
+
+	count := len(ids)
+	hosts := make([]host, 0, count)
+
+	for _, id := range ids {
+		hosts = append(hosts, host{id})
+	}
+
+	data := struct {
+		Count int    `json:"affected_rows"`
+		Hosts []host `json:"returning"`
+	}{count, hosts}
+
+	// Dynamically construct an auxiliary type to serialize the mock response
+	// data.
+	t := reflect.StructOf([]reflect.StructField{
+		{
+			Name: "Response",
+			Type: reflect.TypeOf(data),
+			Tag:  reflect.StructTag(fmt.Sprintf(`json:"%s"`, field)),
+		},
+	})
+	v := reflect.New(t)
+
+	v.Elem().FieldByName("Response").Set(reflect.ValueOf(data))
+
+	return json.Marshal(v.Interface())
+}
+
+// testClient provides mock responses to GraphQL mutations.
+type testClient struct {
+	// ids contains mock instance IDs of unresponsive instances.
+	ids []string
+}
+
+// Initialize is part of the subscriptions.WhistGraphQLClient interface.
+func (*testClient) Initialize(bool) error {
+	return nil
+}
+
+// Query is part of the subscriptions.WhistGraphQLClient interface.
+func (*testClient) Query(context.Context, subscriptions.GraphQLQuery, map[string]interface{}) error {
+	return nil
+}
+
+// Mutate is part of the subscriptions.WhistGraphQLClient interface. This
+// implementation populates the mutation struct with mock host data.
+func (c *testClient) Mutate(_ context.Context, q subscriptions.GraphQLQuery, v map[string]interface{}) error {
+	// Depending what kind of mock response we are providing, we select a list of
+	// instance IDs to return.
+	var ids []string
+	var field string
+
+	switch q.(type) {
+	case *subscriptions.LockBrokenInstances:
+		field = "update_whist_instances"
+
+		// We are providing a mock response to markForTermination, so we use the
+		// list of instance IDs stored in the "database" (i.e. struct)
+		ids = c.ids
+	case *subscriptions.TerminateLockedInstances:
+		field = "delete_whist_instances"
+
+		// We are providing a mock response to finalizeTermination, so we use the
+		// value of the instance IDs input variable.
+		tmp1, ok := v["ids"]
+
+		if !ok {
+			return errors.New("missing instance IDs variable")
+		}
+
+		tmp2, ok := tmp1.([]graphql.String)
+
+		if !ok {
+			return errors.New("instance IDs input variable should be a slice of " +
+				"graphql String types.")
+		}
+
+		ids = make([]string, 0, len(tmp2))
+
+		for _, id := range tmp2 {
+			ids = append(ids, string(id))
+		}
+	default:
+		t := reflect.TypeOf(q)
+		return fmt.Errorf("unrecognized mutation '%s'", t)
+	}
+
+	data, err := mockResponse(field, ids)
+
+	if err != nil {
+		return err
+	}
+
+	// Deserialize the mock data into the response struct.
+	if err := graphql.UnmarshalGraphQL(data, q); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TestLockBrokenInstances tests that LockBrokenInstances converts the GraphQL
+// mutation response from Hasura to a slice of instance IDs.
+func TestLockBrokenInstances(t *testing.T) {
+	var tt time.Time
+	ids := []string{"instance-0", "instance-1", "instance-2"}
+	client := &testClient{ids: ids}
+	res, err := pkg.LockBrokenInstances(context.TODO(), client, "us-east-1", tt)
+
+	if err != nil {
+		t.Error("markForTermination:", err)
+	} else if !reflect.DeepEqual(res, ids) {
+		t.Error(fmt.Printf("Expected %v, got %v", ids, res))
+	}
+}
+
+// TestTerminateLockedInstances tests that TerminateLockedInstances converts
+// the GraphQL mutation response from Hasura to a slice of instance IDs.
+func TestTerminateLockedInstances(t *testing.T) {
+	client := &testClient{}
+	ids := []string{"instance-0", "instance-1", "instance-2"}
+	res, err := pkg.TerminateLockedInstances(context.TODO(), client, "us-east-1", ids)
+
+	if err != nil {
+		t.Error("finalizeTermination:", err)
+	} else if !reflect.DeepEqual(res, ids) {
+		t.Error(fmt.Printf("Expected %v, got %v", ids, res))
+	}
+}

--- a/backend/services/scaling-service/dbclient/client.go
+++ b/backend/services/scaling-service/dbclient/client.go
@@ -11,6 +11,7 @@ package dbclient
 
 import (
 	"context"
+	"time"
 
 	"github.com/whisthq/whist/backend/services/subscriptions"
 )
@@ -37,6 +38,9 @@ type WhistDBClient interface {
 	QueryUserMandelboxes(context.Context, subscriptions.WhistGraphQLClient, string) ([]subscriptions.Mandelbox, error)
 	InsertMandelboxes(context.Context, subscriptions.WhistGraphQLClient, []subscriptions.Mandelbox) (int, error)
 	UpdateMandelbox(context.Context, subscriptions.WhistGraphQLClient, subscriptions.Mandelbox) (int, error)
+
+	LockBrokenInstances(context.Context, subscriptions.WhistGraphQLClient, string, time.Time) ([]string, error)
+	TerminateLockedInstances(context.Context, subscriptions.WhistGraphQLClient, string, []string) ([]string, error)
 }
 
 // DBClient implements `WhistDBClient`, it is the default database

--- a/backend/services/scaling-service/dbclient/types.go
+++ b/backend/services/scaling-service/dbclient/types.go
@@ -1,49 +1,10 @@
 package dbclient
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/hasura/go-graphql-client"
 )
-
-// The timestamptz2 type is an alias for the Time type from the standard library
-// time package. Graphql query variables that are timestamps should be instances
-// of the timestamptz2 type. For example:
-//
-//	var c graphql.Client
-//	var q struct { ... }
-//
-//	v := map[string]interface{}{
-//	    "now": timestamptz2(time.Now()),
-//	}
-//
-//	_ := client.Query(context.TODO(), &q, v)
-//
-// This type serves two purposes:
-//
-//  1. It allows us to provide a custom implementation of the Marshaler
-//     interface from the json package. The graphql client encodes query
-//     variables as JSON before it passes them to the graphql server. Specifying
-//     a custom implementation of the Marshaler interface for the timestamptz2
-//     type allows us to ensure that timestamp variables are serialized
-//     correctly.
-//  2. It specifies the name of the variable's graphql type. In particular,
-//     timestamptz. Had we not implemented the GraphQLType interface from the
-//     github.com/hasura/go-graphql-client package, the graphql type name would
-//     have matched the Go type name, i.e. timestamptz2.
-type timestamptz2 time.Time
-
-// MarshalJSON implements the Marshaler interface from the standard library
-// encoding/json package. It marshals a timestamptz into a JSON string
-// containing a timestamp formatted according to the ISO 8601 standard.
-func (t timestamptz2) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, time.Time(t).Format(time.RFC3339))), nil
-}
-
-func (t timestamptz2) GetGraphQLType() string {
-	return "timestamptz"
-}
 
 // The following types are not idiomatic go, but are necessary so that Hasura
 // can properly recognize mutation inputs and enum types.

--- a/backend/services/scaling-service/event_handler.go
+++ b/backend/services/scaling-service/event_handler.go
@@ -51,8 +51,10 @@ import (
 )
 
 func main() {
-	var cleanupPeriod time.Duration
-	var noCleanup bool
+	var (
+		cleanupPeriod time.Duration
+		noCleanup bool
+	)
 
 	flag.DurationVar(&cleanupPeriod, "cleanup", time.Duration(time.Minute),
 		"the amount of time between when each cleanup thread runs")

--- a/backend/services/scaling-service/event_handler.go
+++ b/backend/services/scaling-service/event_handler.go
@@ -42,6 +42,7 @@ import (
 	"github.com/whisthq/whist/backend/services/metadata"
 	"github.com/whisthq/whist/backend/services/scaling-service/config"
 	"github.com/whisthq/whist/backend/services/scaling-service/dbclient"
+	hosts "github.com/whisthq/whist/backend/services/scaling-service/hosts/aws"
 	algos "github.com/whisthq/whist/backend/services/scaling-service/scaling_algorithms/default" // Import as algos, short for scaling_algorithms
 	"github.com/whisthq/whist/backend/services/subscriptions"
 	"github.com/whisthq/whist/backend/services/utils"
@@ -117,28 +118,51 @@ func main() {
 	// Use a sync map since we only write the keys once but will be reading multiple
 	// times by different goroutines.
 	algorithmByRegionMap := &sync.Map{}
+	regions := config.GetEnabledRegions()
+	stopFuncs := make([]func(), 0, len(regions))
 
-	// Load default scaling algorithm for all enabled regions.
-	for _, region := range config.GetEnabledRegions() {
+	// Load and instantiate default scaling algorithm for all enabled regions.
+	for _, region := range regions {
+		name := utils.Sprintf("default-sa-%s", region)
+		handler := &hosts.AWSHost{}
+
+		if err := handler.Initialize(region); err != nil {
+			logger.Errorf("Failed to initialize host handler for region '%s'", region)
+			continue
+		}
+
+		algo := &algos.DefaultScalingAlgorithm{Host: handler, Region: region}
+
+		algo.CreateEventChans()
+		algo.CreateGraphQLClient(graphqlClient)
+		algo.CreateDBClient(dbClient)
+		algo.ProcessEvents(globalCtx, goroutineTracker)
+
+		stop := CleanRegion(graphqlClient, handler)
+
+		stopFuncs = append(stopFuncs, stop)
+		algorithmByRegionMap.Store(name, algo)
+
 		logger.Infof("There should be as close as possible to %d unassigned "+
 			"Mandelboxes available at all times in %s",
 			config.GetTargetFreeMandelboxes(region), region)
-		name := utils.Sprintf("default-sa-%s", region)
-		algorithmByRegionMap.Store(name, &algos.DefaultScalingAlgorithm{
-			Region: region,
-		})
 	}
 
-	// Instantiate scaling algorithms on allowed regions
-	algorithmByRegionMap.Range(func(key, value interface{}) bool {
-		scalingAlgorithm := value.(algos.ScalingAlgorithm)
-		scalingAlgorithm.CreateEventChans()
-		scalingAlgorithm.CreateGraphQLClient(graphqlClient)
-		scalingAlgorithm.CreateDBClient(dbClient)
-		scalingAlgorithm.ProcessEvents(globalCtx, goroutineTracker)
+	// Wait for each of our cleanup threads to finish before we exit.
+	defer func() {
+		var wg sync.WaitGroup
 
-		return true
-	})
+		for j := range stopFuncs {
+			wg.Add(1)
+
+			go func(i int) {
+				defer wg.Done()
+				stopFuncs[i]()
+			}(j)
+		}
+
+		wg.Wait()
+	}()
 
 	// Start main event loop
 	go eventLoop(globalCtx, globalCancel, serverEvents, subscriptionEvents, scheduledEvents, algorithmByRegionMap, configClient)

--- a/backend/services/scaling-service/scaling_algorithms/default/actions_test.go
+++ b/backend/services/scaling-service/scaling_algorithms/default/actions_test.go
@@ -5,6 +5,7 @@ package scaling_algorithms
 
 import (
 	"context"
+	"errors"
 	"os"
 	"sync"
 	"testing"
@@ -191,6 +192,14 @@ func (db *mockDBClient) UpdateMandelbox(_ context.Context, _ subscriptions.Whist
 	}
 
 	return affected, nil
+}
+
+func (db *mockDBClient) LockBrokenInstances(context.Context, subscriptions.WhistGraphQLClient, string, time.Time) ([]string, error) {
+	return nil, errors.New("Not implemented")
+}
+
+func (db *mockDBClient) TerminateLockedInstances(context.Context, subscriptions.WhistGraphQLClient, string, []string) ([]string, error) {
+	return nil, errors.New("Not implemented")
 }
 
 // mockHostHandler is used to test all interactions with cloud providers

--- a/backend/services/scaling-service/scaling_algorithms/default/default.go
+++ b/backend/services/scaling-service/scaling_algorithms/default/default.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/whisthq/whist/backend/services/scaling-service/dbclient"
 	"github.com/whisthq/whist/backend/services/scaling-service/hosts"
-	aws "github.com/whisthq/whist/backend/services/scaling-service/hosts/aws"
 	"github.com/whisthq/whist/backend/services/subscriptions"
 	"github.com/whisthq/whist/backend/services/utils"
 	logger "github.com/whisthq/whist/backend/services/whistlogger"
@@ -117,19 +116,6 @@ func (s *DefaultScalingAlgorithm) CreateDBClient(dbClient dbclient.WhistDBClient
 // events and executing the appropiate scaling actions. This function is specific for each region
 // scaling algorithm to be able to implement different strategies on each region.
 func (s *DefaultScalingAlgorithm) ProcessEvents(globalCtx context.Context, goroutineTracker *sync.WaitGroup) {
-	if s.Host == nil {
-		// TODO when multi-cloud support is introduced, figure out a way to
-		// decide which host to use. For now default to AWS.
-		handler := &aws.AWSHost{}
-		err := handler.Initialize(s.Region)
-
-		if err != nil {
-			logger.Errorf("error starting host in %s: %s", s.Region, err)
-		}
-
-		s.Host = handler
-	}
-
 	// Start algorithm main event loop
 	// Track this goroutine so we can wait for it to
 	// finish if the global context gets cancelled.

--- a/backend/services/subscriptions/mutations.go
+++ b/backend/services/subscriptions/mutations.go
@@ -2,6 +2,43 @@ package subscriptions
 
 import "github.com/hasura/go-graphql-client"
 
+type (
+
+	// LockBrokenInstances takes two arguments: region and maxAge. The region
+	// argument matches values from the region column of the whist.instances
+	// table. The maxAge argument is a timestamptz that specifies the time after
+	// which, if an instance has not updated itself in the database, it will be
+	// considered broken. This query gives the status column of all rows of the
+	// database that have an updated_at timestamp that is older than maxAge the
+	// TERMINATING status. It returns the instance_ids of the affected rows.
+	LockBrokenInstances struct {
+		Response struct {
+			Count graphql.Int `graphql:"affected_rows"`
+			Hosts []struct {
+				ID graphql.String `graphql:"id"`
+			} `graphql:"returning"`
+		} `graphql:"update_whist_instances(where: {region: {_eq: $region}, updated_at: {_lt: $maxAge}, status: {_neq: \"TERMINATING\"}}, _set: {status: \"TERMINATING\"})"`
+	}
+
+	// TerminateLockedInstances takes two arguments: region and ids. The region
+	// argument matches values from the region column of the whist.instances
+	// table. The ids argument specifies the instance_ids of the instances to
+	// terminate. All of these instances should already be locked, i.e. the status
+	// column of each of their rows in the whist.instances database should have
+	// TERMINATING.
+	TerminateLockedInstances struct {
+		MandelboxesResponse struct {
+			Count graphql.Int `graphql:"affected_rows"`
+		} `graphql:"delete_whist_mandelboxes(where: {instance: {region: {_eq: $region}, id: {_in: $ids}, status: {_eq: \"TERMINATING\"}}})"`
+		InstancesResponse struct {
+			Count graphql.Int `graphql:"affected_rows"`
+			Hosts []struct {
+				ID graphql.String `graphql:"id"`
+			} `graphql:"returning"`
+		} `graphql:"delete_whist_instances(where: {region: {_eq: $region}, id: {_in: $ids}, status: {_eq: \"TERMINATING\"}})"`
+	}
+)
+
 var (
 
 	// InsertInstances inserts multiple instances to the database.

--- a/backend/services/subscriptions/mutations.go
+++ b/backend/services/subscriptions/mutations.go
@@ -17,7 +17,7 @@ type (
 			Hosts []struct {
 				ID graphql.String `graphql:"id"`
 			} `graphql:"returning"`
-		} `graphql:"update_whist_instances(where: {region: {_eq: $region}, updated_at: {_lt: $maxAge}, status: {_neq: \"TERMINATING\"}}, _set: {status: \"TERMINATING\"})"`
+		} `graphql:"update_whist_instances(where: {region: {_eq: $region}, updated_at: {_lt: $maxAge}, status: {_in: [\"ACTIVE\", \"TERMINATING\"]}}, _set: {status: \"TERMINATING\"})"`
 	}
 
 	// TerminateLockedInstances takes two arguments: region and ids. The region


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #7399 

**Description**

This PR adds code to the scaling service that prevents broken instances from existing for too long. Although the linked issue calls for broken instances to be marked as DRAINING, this PR terminates them directly. Normally, when the host service notices that it has been marked as draining in the database, it waits until all users have disconnected, shuts down all running Mandelboxes, and terminates itself. The tricky thing about broken instances is that they're broken, so we can't assume they can or will do any of those things. For this reason, broken instances need to be terminated directly, not just marked as DRAINING.

**Implementation**

Run a cleanup thread in each region. Every cleanup period, the cleanup threads look for unresponsive instances. An unresponsive instance is one that hasn't sent a ping in at least 2 minutes. If all unresponsive instances can be terminated, also delete the corresponding rows from the database. If termination of one or more instances fails, log an error, but do not remove any rows from the database.

**Documentation & Tests Added**

Just godoc comments.

**Testing Instructions**

1. Create an instance (any instance). We just need _an_ instance that we can practice deleting.
2. Spin up a local database and config database.
3. Add a row for the instance you created in step 1 to your local scaling service database (if your database is empty, you'll need to add a row to the images table as well, but you can just call it fake-image or something)
4. Remove the `-nocleanup` flag from the command line in the `run_scaling_service_localdevwithdb` target.
5. Start the scaling service with `make run_scaling_service_localdevwithdb`
6. After about a minute, the scaling service should delete the row from the database and terminate the instance.

**PR Checklist**

- [x] Did the PR author fully test this PR end-to-end?
- [ ] Did one PR reviewer fully test this PR end-to-end?
- [ ] Did one PR reviewer conduct a thorough code design review?
