### PR TITLE
Formalize MongoDB deployment

### DIFF
--- a/backend/infrastructure/dev/main.tf
+++ b/backend/infrastructure/dev/main.tf
@@ -29,6 +29,11 @@ module "s3" {
   env    = var.env
 }
 
+# Dashboard database provider. Credentials are filled in by CI and
+# passed as environment variables to terraform.
+provider "mongodbatlas" {}
+
+
 # Region-specific modules, these are enabled only on certain regions
 
 # Enable all AWS regions on Terraform. Doing this will create

--- a/backend/infrastructure/modules/mongodbatlas_cluster/main.tf
+++ b/backend/infrastructure/modules/mongodbatlas_cluster/main.tf
@@ -1,0 +1,52 @@
+resource "mongodbatlas_advanced_cluster" "dashboard_cluster" {
+  project_id            = var.project_id
+  name                  = var.cluster_name
+  cluster_type          = "REPLICASET"
+  mongodb_major_version = var.mongodbversion
+  replication_specs {
+    electable_specs {
+      instance_size = "M0"
+      node_count    = 3
+    }
+    analytics_specs {
+      instance_size = "M0"
+      node_count    = 1
+    }
+    provider_name = var.cloud_provider
+    priority      = 1
+    region_name   = var.region
+  }
+}
+
+resource "mongodbatlas_project_ip_access_list" "ip" {
+  project_id = var.project.id
+
+  # Note: Since the Netlify site changes ip address constantly,
+  # we allow access for all ip addresses. Other methods should
+  # be used to authorize access to the cluster.
+  ip_address = "0.0.0.0/0"
+  comment    = "Allow access to all ip addresses."
+}
+
+resource "mongodbatlas_database_user" "dashboard_user" {
+  # TODO: Credentials should be filled in by CI.
+  username           = ""
+  password           = ""
+  project_id         = var.project_id
+  auth_database_name = "admin"
+
+  roles {
+    role_name     = "readWrite"
+    database_name = var.database_name # The database name and collection name need not exist in the cluster before creating the user.
+  }
+
+  scopes {
+    name = var.cluster_name
+    type = "CLUSTER"
+  }
+
+  labels {
+    key   = "Name"
+    value = "Dashboard User"
+  }
+}

--- a/backend/infrastructure/modules/mongodbatlas_cluster/variables.tf
+++ b/backend/infrastructure/modules/mongodbatlas_cluster/variables.tf
@@ -1,0 +1,24 @@
+variable "org_id" {
+  type        = string
+  description = "MongoDB Organization ID"
+}
+variable "project_id" {
+  type        = string
+  description = "The MongoDB Atlas Project ID"
+}
+variable "cluster_name" {
+  type        = string
+  description = "The MongoDB Atlas Cluster Name"
+}
+variable "cloud_provider" {
+  type        = string
+  description = "The cloud provider to use, must be AWS, GCP or AZURE"
+}
+variable "region" {
+  type        = string
+  description = "MongoDB Atlas Cluster Region, must be a region for the provider given"
+}
+variable "mongodbversion" {
+  type        = string
+  description = "The Major MongoDB Version"
+}

--- a/backend/infrastructure/modules/mongodbatlas_project/main.tf
+++ b/backend/infrastructure/modules/mongodbatlas_project/main.tf
@@ -1,0 +1,16 @@
+resource "mongodbatlas_project" "dashboard" {
+  name   = var.project_name
+  org_id = var.org_id
+
+  # TODO: not sure if these options are enabled by default or
+  # are addons that incur in costs.
+  is_collect_database_specifics_statistics_enabled = true
+  is_data_explorer_enabled                         = true
+  is_performance_advisor_enabled                   = true
+  is_realtime_performance_panel_enabled            = true
+  is_schema_advisor_enabled                        = true
+}
+
+output "project_id" {
+  value = mongodbatlas_project.dashboard.id
+}

--- a/backend/infrastructure/modules/mongodbatlas_project/variables.tf
+++ b/backend/infrastructure/modules/mongodbatlas_project/variables.tf
@@ -1,0 +1,8 @@
+variable "org_id" {
+  type        = string
+  description = "MongoDB Organization ID"
+}
+variable "project_name" {
+  type        = string
+  description = "The MongoDB Atlas Project Name"
+}


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**Description**
This PR adds MongoDB Atlas configurations to Terrafom. This will allow us to manage the db clusters easily and we can deploy them per environment as the rest of the infrastructure.

TODO:
- [ ] Pass Mongo api key via Github secrets
- [ ] Pass user and password via secrets/GHA
- [ ] Update GHA to set environment vars before running terraform commands

**Implementation**
I used the mongodbatlas terraform provider to add all necessary configurations.

**Documentation & Tests Added**

**Testing Instructions**

**PR Checklist**

- [ ] Did the PR author fully test this PR end-to-end?
- [ ] Did one PR reviewer fully test this PR end-to-end?
- [ ] Did one PR reviewer conduct a thorough code design review?
